### PR TITLE
request handler を作成する関数を、各エンドポイントに用意

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -78,13 +78,13 @@ describe('createMock', () => {
     const api = (({ baseURL: _baseURL }) => ({
       items: {
         _itemId: (itemId: string) => ({
-          $get: () => Promise.resolve(''),
+          $get: () => Promise.resolve({ foo: 'bar' }),
           $path: () => `${_baseURL}/items/${itemId}`,
           variants: {
-            $get: () => Promise.resolve(''),
+            $get: () => Promise.resolve({ foo: 'bar' }),
             $path: () => `${_baseURL}/items/${itemId}/variants`,
             _variantId: (variantId: number) => ({
-              $get: () => Promise.resolve(''),
+              $get: () => Promise.resolve({ foo: 'bar' }),
               $path: () => `${_baseURL}/items/${itemId}/variants/${variantId}`,
             }),
           },
@@ -92,12 +92,11 @@ describe('createMock', () => {
       },
     })) satisfies AspidaApi;
     const mock = createMock(api, baseURL);
-
     const handler = mock.items
       ._itemId()
       .variants._variantId()
       .$get((req, res, ctx) =>
-        res.once(ctx.status(200), ctx.json({ foo: 'bar' })),
+        res.once(ctx.status(200), ctx.json({ foo: 'baz' })),
       );
 
     expect(handler).toBeInstanceOf(RestHandler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { ResponseResolver, rest } from 'msw';
 import { LowerHttpMethod } from 'aspida';
-import { ApiStructure, AspidaApi, Endpoint, MockApi } from './type.js';
+import {
+  $LowerHttpMethod,
+  ApiStructure,
+  AspidaApi,
+  Endpoint,
+  MockApi,
+} from './type.js';
 
 const METHODS = [
   'get',
@@ -19,7 +25,7 @@ const $METHODS = [
   '$head',
   '$patch',
   '$options',
-] satisfies `$${LowerHttpMethod}`[];
+] satisfies $LowerHttpMethod[];
 
 function createMockFromApiStructure<T extends ApiStructure>(
   apiStructure: T,
@@ -30,7 +36,7 @@ function createMockFromApiStructure<T extends ApiStructure>(
         return { ...acc, $path: value };
       }
 
-      if ($METHODS.includes(key as `$${LowerHttpMethod}`)) {
+      if ($METHODS.includes(key as $LowerHttpMethod)) {
         // そのメソッドのモック生成関数を返す
         const method = key.substring(1) as LowerHttpMethod;
         const path = (apiStructure as Endpoint).$path();

--- a/src/type.ts
+++ b/src/type.ts
@@ -6,7 +6,7 @@ type PathParamFunction =
   | ((param: string) => ApiStructure)
   | ((param: number) => ApiStructure);
 
-type Endpoint = { $path: () => string } & {
+export type Endpoint = { $path: () => string } & {
   [K in LowerHttpMethod | `$${LowerHttpMethod}`]?: (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     option?: any,

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,9 @@
-import type { AspidaClient, LowerHttpMethod } from 'aspida';
+import type {
+  AspidaClient,
+  AspidaParams,
+  AspidaResponse,
+  LowerHttpMethod,
+} from 'aspida';
 import { ResponseResolver, RestHandler, RestRequest } from 'msw';
 
 // api
@@ -7,12 +12,15 @@ type PathParamFunction =
   | ((param: string) => ApiStructure)
   | ((param: number) => ApiStructure);
 
-export type Endpoint = { $path: () => string } & {
-  [K in LowerHttpMethod | `$${LowerHttpMethod}`]?: (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    option?: any,
-  ) => Promise<unknown>;
-};
+type MethodFetch = (option: Required<AspidaParams>) => Promise<AspidaResponse>;
+type $MethodFetch = (
+  option: Required<AspidaParams>,
+) => Promise<AspidaResponse['body']>;
+
+export type Endpoint = Partial<Record<LowerHttpMethod, MethodFetch>> &
+  Partial<Record<`$${LowerHttpMethod}`, $MethodFetch>> & {
+    $path: () => string;
+  };
 
 type NonEndpoint = {
   [K in string]: ApiStructure | PathParamFunction;

--- a/src/type.ts
+++ b/src/type.ts
@@ -41,10 +41,7 @@ type MockPathParamFunction<T extends PathParamFunction> = () => MockApi<
   ReturnType<T>
 >;
 
-type MockEndpointKey<T extends ApiStructure> = Exclude<
-  Extract<keyof T, keyof Endpoint>,
-  LowerHttpMethod
->;
+type MockMethod<T extends ApiStructure> = Extract<keyof T, $LowerHttpMethod>;
 
 type HandlerCreator<T> = // TODO: T[K] からリクエストの型を抽出して、RestRequest の型パラメータ RequestBody に渡す
   // RestRequest<RequestBody extends DefaultBodyType = DefaultBodyType, RequestParams extends PathParams = PathParams>
@@ -53,10 +50,8 @@ type HandlerCreator<T> = // TODO: T[K] からリクエストの型を抽出し�
   (resolver: ResponseResolver<RestRequest>) => RestHandler;
 
 type MockEndpoint<T extends ApiStructure> = {
-  [K in MockEndpointKey<T>]: K extends '$path'
-    ? () => string
-    : HandlerCreator<T[K]>;
-};
+  [K in MockMethod<T>]: HandlerCreator<T[K]>;
+} & { $path: () => string };
 
 type MockNonEndpointKey<T extends ApiStructure> = Exclude<
   keyof T,

--- a/src/type.ts
+++ b/src/type.ts
@@ -10,10 +10,6 @@ export type $LowerHttpMethod = `$${LowerHttpMethod}`;
 
 // api
 
-type PathParamFunction =
-  | ((param: string) => ApiStructure)
-  | ((param: number) => ApiStructure);
-
 type MethodFetch = (option: Required<AspidaParams>) => Promise<AspidaResponse>;
 type $MethodFetch = (
   option: Required<AspidaParams>,
@@ -23,6 +19,10 @@ export type Endpoint = Partial<Record<LowerHttpMethod, MethodFetch>> &
   Partial<Record<$LowerHttpMethod, $MethodFetch>> & {
     $path: () => string;
   };
+
+type PathParamFunction =
+  | ((param: string) => ApiStructure)
+  | ((param: number) => ApiStructure);
 
 type NonEndpoint = {
   [K in string]: ApiStructure | PathParamFunction;
@@ -36,10 +36,6 @@ export type AspidaApi<T extends ApiStructure = ApiStructure> = ({
 }: AspidaClient<unknown>) => T;
 
 // mock
-
-type MockPathParamFunction<T extends PathParamFunction> = () => MockApi<
-  ReturnType<T>
->;
 
 type MockMethod<T extends ApiStructure> = Extract<keyof T, $LowerHttpMethod>;
 
@@ -59,6 +55,10 @@ type MockEndpoint<T extends ApiStructure> = {
     ? HandlerCreator<T[K]>
     : never;
 } & { $path: () => string };
+
+type MockPathParamFunction<T extends PathParamFunction> = () => MockApi<
+  ReturnType<T>
+>;
 
 type MockNonEndpointKey<T extends ApiStructure> = Exclude<
   keyof T,

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,9 +16,7 @@ export type $LowerHttpMethod = `$${LowerHttpMethod}`;
 // api
 
 type MethodFetch = (option: Required<AspidaParams>) => Promise<AspidaResponse>;
-type $MethodFetch = (
-  option: Required<AspidaParams>,
-) => Promise<AspidaResponse['body']>;
+type $MethodFetch = (option: Required<AspidaParams>) => Promise<unknown>;
 
 export type Endpoint = Partial<Record<LowerHttpMethod, MethodFetch>> &
   Partial<Record<$LowerHttpMethod, $MethodFetch>> & {

--- a/src/type.ts
+++ b/src/type.ts
@@ -6,6 +6,8 @@ import type {
 } from 'aspida';
 import { ResponseResolver, RestHandler, RestRequest } from 'msw';
 
+export type $LowerHttpMethod = `$${LowerHttpMethod}`;
+
 // api
 
 type PathParamFunction =
@@ -18,7 +20,7 @@ type $MethodFetch = (
 ) => Promise<AspidaResponse['body']>;
 
 export type Endpoint = Partial<Record<LowerHttpMethod, MethodFetch>> &
-  Partial<Record<`$${LowerHttpMethod}`, $MethodFetch>> & {
+  Partial<Record<$LowerHttpMethod, $MethodFetch>> & {
     $path: () => string;
   };
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,5 @@
 import type { AspidaClient, LowerHttpMethod } from 'aspida';
+import { ResponseResolver, RestHandler, RestRequest } from 'msw';
 
 // api
 
@@ -35,11 +36,16 @@ type MockEndpointKey<T extends ApiStructure> = Exclude<
   LowerHttpMethod
 >;
 
+type HandlerCreator<T> = // TODO: T[K] からリクエストの型を抽出して、RestRequest の型パラメータ RequestBody に渡す
+  // RestRequest<RequestBody extends DefaultBodyType = DefaultBodyType, RequestParams extends PathParams = PathParams>
+  // TODO: T[K] からレスポンスの型を抽出して、ResponseResolver の型パラメータ BodyType に渡す
+  // ResponseResolver<RequestType = MockedRequest, ContextType = typeof defaultContext, BodyType extends DefaultBodyType = any>
+  (resolver: ResponseResolver<RestRequest>) => RestHandler;
+
 type MockEndpoint<T extends ApiStructure> = {
   [K in MockEndpointKey<T>]: K extends '$path'
     ? () => string
-    : // TODO: T[K] からリクエストの型とレスポンスの型を抽出する
-      () => string;
+    : HandlerCreator<T[K]>;
 };
 
 type MockNonEndpointKey<T extends ApiStructure> = Exclude<

--- a/src/type.ts
+++ b/src/type.ts
@@ -4,7 +4,12 @@ import type {
   AspidaResponse,
   LowerHttpMethod,
 } from 'aspida';
-import { ResponseResolver, RestContext, RestHandler, RestRequest } from 'msw';
+import type {
+  ResponseResolver,
+  RestContext,
+  RestHandler,
+  RestRequest,
+} from 'msw';
 
 export type $LowerHttpMethod = `$${LowerHttpMethod}`;
 


### PR DESCRIPTION
こんな感じで MSW の request handler を書けるようにする。

```ts
const mock = createMock(api, baseURL);

mock.items._itemId().variants._variantId().$patch(
  (req, res, ctx) => res.once(ctx.status(200), ctx.json({ foo: 'baz' }))
);
```

リクエストボディ（`await req.json()` の戻り値）とレスポンスボディ（`ctx.json()` の引数）には、aspida で吐いた `api` から取り出した型をつける。実際の API と異なる型で request handler を実装した場合、型エラーで検出できる。