### PR TITLE
openapi2aspida が生成したファイル内のインポートが解決できない問題を修正

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,8 +27,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'import/no-default-export': 'error',
 
-    // ESM 非対応。tsc でチェックできているので無効化
-    'import/extensions': 'off',
+    'import/extensions': ['error', 'never'],
 
     // typescript-eslint のルールの方が正確
     'no-use-before-define': 'off',

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,5 +1,5 @@
-import api from './generated-api/$api.js';
-import { createMock } from '../src/index.js';
+import api from './generated-api/$api';
+import { createMock } from '../src';
 
 const mock = createMock(api, 'https://example.com');
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { RestHandler } from 'msw';
-import { createMock } from './index.js';
-import { AspidaApi } from './type.js';
+import { createMock } from '.';
+import { AspidaApi } from './type';
 
 describe('createMock', () => {
   const baseURL = 'https://base-url.example.com/v1';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   AspidaApi,
   Endpoint,
   MockApi,
-} from './type.js';
+} from './type';
 
 const METHODS = [
   'get',

--- a/src/type.ts
+++ b/src/type.ts
@@ -15,7 +15,9 @@ export type $LowerHttpMethod = `$${LowerHttpMethod}`;
 
 // api
 
-type MethodFetch = (option: Required<AspidaParams>) => Promise<AspidaResponse>;
+type MethodFetch = (
+  option: Required<AspidaParams>,
+) => Promise<AspidaResponse<unknown>>;
 type $MethodFetch = (option: Required<AspidaParams>) => Promise<unknown>;
 
 export type Endpoint = Partial<Record<LowerHttpMethod, MethodFetch>> &

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,13 @@
   "extends": [
     "@tsconfig/strictest/tsconfig.json",
     "@tsconfig/node20/tsconfig.json"
-  ]
+  ],
+  "compilerOptions": {
+    // 本当は Node16 を指定して Node.js Native ESM にしたいが、
+    // openapi2aspida の生成するファイルは拡張子なしの import 文が使われているため、
+    // このパッケージの example やテストにおいて import 対象の解決ができない
+    // そこで ES20222/Bundler をとりあえず指定している
+    "module": "ES2022",
+    "moduleResolution": "Bundler"
+  }
 }


### PR DESCRIPTION
## Why?

現在は Node.js Native ESM にしているが、これだと `import` 文に拡張子を付けて書く必要がある。

[Native ESM + TypeScript 拡張子問題: 歯にものが挟まったようなスッキリしない書き流し](https://zenn.dev/qnighy/articles/19603f11d5f264)

しかし、openapi2aspida は以下のように拡張子なしでファイルを生成するため、import が解決できず、エラーになる。

<img width="652" alt="example_generated-api__api_ts_—_aspida-msw" src="https://github.com/mashabow/aspida-msw/assets/6268183/905eac12-d028-4a23-9612-6296b7aa6643">

問題が起きるのは使用例（`example/`）と、（これから openapi2aspida を使って作る予定の）テストのみ。パッケージ利用者が openapi2aspida と組み合わせて使う分には、このパッケージが Node.js Native ESM であったとしても、パッケージが異なるので問題は起きないはず。

## How?

`tsconfig.json` の設定を変えて一旦 Node.js Native ESM をあきらめる。

別の方法として、このリポジトリ内で openapi2aspida を使っている箇所を別バッケージ（workspace）に切り出し、そちらだけ `tsconfig.json` を変える、というやり方も考えられる。が、ちょっと大掛かりになるので採用しない。